### PR TITLE
fixing ci build with wrong vcs flag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
           go-version-file: go.mod
       - name: Build Stage Control for GOOS=${{matrix.os}} GOARCH=${{matrix.arch}} (${{matrix.arch}})
         run: |
-          GOOS=${{matrix.os}} GOARCH=${{matrix.arch}} go build -buildvsc -o dist/stage-contol-${{matrix.os}}-${{matrix.arch}} .
+          GOOS=${{matrix.os}} GOARCH=${{matrix.arch}} go build -buildvcs -o dist/stage-contol-${{matrix.os}}-${{matrix.arch}} .
       - run: mv dist/stage-contol-${{matrix.os}}-${{matrix.arch}} dist/stage-contol-${{matrix.os}}-${{matrix.arch}}.exe
         if: ${{matrix.os == 'windows' }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR merges changes to the build command to fix an issue with the `go build` command